### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,10 +13,10 @@ Motor	KEYWORD1
 #######################################
 
 doSomething	KEYWORD2
-run KEYWORD2
-stop KEYWORD2
-setSpeed KEYWORD2
-getDir KEYWORD2
+run	KEYWORD2
+stop	KEYWORD2
+setSpeed	KEYWORD2
+getDir	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords